### PR TITLE
Update calendar ID to match Google's change

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -39,7 +39,7 @@ function checkBirthdays (testDate) {
   var anticipate = anticipateDays.map(function (n) { return 1000 * 60 * 60 * 24 * n; });
 
   // Unique ID of the calendar containing birthdays.
-  var calendarId = '#contacts@group.v.calendar.google.com';
+  var calendarId = 'addressbook#contacts@group.v.calendar.google.com';
 
   // Verify that the birthday calendar exists.
   if (!CalendarApp.getCalendarById(calendarId)) {


### PR DESCRIPTION
For me this script stopped working since yesterday, and by looking at the "calendar settings" of the "birthday calendar" in the web interface I noticed it had just changed from `#contacts@group.v.calendar.google.com` to `addressbook#contacts@group.v.calendar.google.com`. When I applied that change the script worked again (for me... but I doubt this change would be specific to me? it must be for everyone, right?).